### PR TITLE
Updated 'byo'

### DIFF
--- a/hiragana.json
+++ b/hiragana.json
@@ -531,7 +531,7 @@
     },
     {
         "char_id": "byo",
-        "character": "にょ",
+        "character": "びょ",
         "romanization": "byo"
     },
     {


### PR DESCRIPTION
'nyo' was erroneously used in place of byo